### PR TITLE
Fixed Table of Contents Links and Color issues

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -6,7 +6,6 @@
 	linktoc=all,     %set to all if you want both sections and subsections linked
 	linkcolor=blue,  %choose some color if you want links to stand out
 }
-
 \usepackage{taoesolutions}
 
 \begin{document}

--- a/taoesolutions.sty
+++ b/taoesolutions.sty
@@ -12,15 +12,21 @@
   footskip=30pt,
 ]{geometry}
 \usepackage[toc]{multitoc}
+\usepackage{xcolor}
 
 % Remove the "Chapter" label on each chapter
 \usepackage{titlesec}
 \titleformat{\chapter}[display]
     {\normalfont\bfseries}{}{0pt}{\huge}
 
+% suppress section numbering
+\makeatletter
+\renewcommand\@seccntformat[1]{}
+\makeatother
 % Define a consistent "Exercise" delineator
-\newcommand{\ex}[1]{\section*{Exercise #1} \addcontentsline{toc}{section}{Exercise #1}}
+\newcommand{\ex}[1]{\section{Exercise #1}}
 
+\colorlet{RED}{red} % protect against upper-case RED issues...
 \newcommand{\todo}[1]{\textcolor{red}{\textbf{TODO: #1}}}
 \newcommand{\todoex}[1]{\ex{#1 \todo{write solution}}}
 \newcommand{\mans}[1]{\boxed{#1}}


### PR DESCRIPTION
Sections now have their numbers suppressed.
Previously, sections were defined with 'section*{}'.
The asterisk prevented the numbers from appearing in the TOC.
But the asterisk was also interfering with the hyperref package.
So sections are now definted without the asterisk.

somewhere in the LaTeX code, it is changing 'red' to 'RED', so I had to
create a special translation so that xcolor doesn't throw a fit.